### PR TITLE
Add registration certificate upload and compliance fields

### DIFF
--- a/src/main/java/com/startupsphere/capstone/entity/Startup.java
+++ b/src/main/java/com/startupsphere/capstone/entity/Startup.java
@@ -98,6 +98,33 @@ public class Startup {
     @Column(name = "last_updated", nullable = true)
     private LocalDateTime lastUpdated;
 
+    // Registration & Compliance fields
+    @Column(name = "is_government_registered")
+    private Boolean isGovernmentRegistered;
+
+    @Column(name = "registration_agency")
+    private String registrationAgency;
+
+    @Column(name = "registration_number")
+    private String registrationNumber;
+
+    @Column(name = "registration_date")
+    private String registrationDate;
+
+    @Column(name = "other_registration_agency")
+    private String otherRegistrationAgency;
+
+    @Column(name = "business_license_number")
+    private String businessLicenseNumber;
+
+    @Column(name = "tin")
+    private String tin;
+
+    // Registration certificate as file (image, any extension)
+    @Lob
+    @Column(name = "registration_certificate", columnDefinition = "LONGBLOB")
+    private byte[] registrationCertificate;
+
     public Startup() {
     }
 
@@ -611,5 +638,69 @@ public class Startup {
 
     public void setLastUpdated(LocalDateTime lastUpdated) {
         this.lastUpdated = lastUpdated;
+    }
+
+    public Boolean getIsGovernmentRegistered() {
+        return isGovernmentRegistered;
+    }
+
+    public void setIsGovernmentRegistered(Boolean isGovernmentRegistered) {
+        this.isGovernmentRegistered = isGovernmentRegistered;
+    }
+
+    public String getRegistrationAgency() {
+        return registrationAgency;
+    }
+
+    public void setRegistrationAgency(String registrationAgency) {
+        this.registrationAgency = registrationAgency;
+    }
+
+    public String getRegistrationNumber() {
+        return registrationNumber;
+    }
+
+    public void setRegistrationNumber(String registrationNumber) {
+        this.registrationNumber = registrationNumber;
+    }
+
+    public String getRegistrationDate() {
+        return registrationDate;
+    }
+
+    public void setRegistrationDate(String registrationDate) {
+        this.registrationDate = registrationDate;
+    }
+
+    public String getOtherRegistrationAgency() {
+        return otherRegistrationAgency;
+    }
+
+    public void setOtherRegistrationAgency(String otherRegistrationAgency) {
+        this.otherRegistrationAgency = otherRegistrationAgency;
+    }
+
+    public String getBusinessLicenseNumber() {
+        return businessLicenseNumber;
+    }
+
+    public void setBusinessLicenseNumber(String businessLicenseNumber) {
+        this.businessLicenseNumber = businessLicenseNumber;
+    }
+
+    public String getTin() {
+        return tin;
+    }
+
+    public void setTin(String tin) {
+        this.tin = tin;
+    }
+
+    public byte[] getRegistrationCertificate() {
+        return registrationCertificate;
+    }
+
+    public void setRegistrationCertificate(byte[] registrationCertificate) {
+        this.registrationCertificate = registrationCertificate;
     }
 }

--- a/src/main/java/com/startupsphere/capstone/service/StartupService.java
+++ b/src/main/java/com/startupsphere/capstone/service/StartupService.java
@@ -124,8 +124,20 @@ public class StartupService {
                     startup.setVerificationCode(updatedStartup.getVerificationCode());
                     startup.setEmailVerified(updatedStartup.getEmailVerified());
 
+                    // Registration & Compliance fields
+                    startup.setIsGovernmentRegistered(updatedStartup.getIsGovernmentRegistered());
+                    startup.setRegistrationAgency(updatedStartup.getRegistrationAgency());
+                    startup.setRegistrationNumber(updatedStartup.getRegistrationNumber());
+                    startup.setRegistrationDate(updatedStartup.getRegistrationDate());
+                    startup.setOtherRegistrationAgency(updatedStartup.getOtherRegistrationAgency());
+                    startup.setBusinessLicenseNumber(updatedStartup.getBusinessLicenseNumber());
+                    startup.setTin(updatedStartup.getTin());
+
                     if (updatedStartup.getPhoto() != null) {
                         startup.setPhoto(updatedStartup.getPhoto());
+                    }
+                    if (updatedStartup.getRegistrationCertificate() != null) {
+                        startup.setRegistrationCertificate(updatedStartup.getRegistrationCertificate());
                     }
 
                     return startupRepository.save(startup);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,9 @@
 spring.application.name=capstone
 
-spring.datasource.url=jdbc:mysql://localhost:3306/startupsphere
+spring.datasource.url=jdbc:mysql://turntable.proxy.rlwy.net:30171/railway
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.username=root
-spring.datasource.password=12345
+spring.datasource.password=lruACZcqktvLwHYvTRzpNwUCBSZdYwvi
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 server.error.include-stacktrace=never


### PR DESCRIPTION
Introduced endpoints to upload and retrieve registration certificates for startups. Added new registration and compliance fields to the Startup entity, including government registration status, agency, number, date, business license, and TIN. Updated the service layer to handle these new fields. Also updated the database connection properties.