### PR TITLE
Restrict CORS and enhance JWT cookie handling

### DIFF
--- a/src/main/java/com/startupsphere/capstone/configs/SecurityConfiguration.java
+++ b/src/main/java/com/startupsphere/capstone/configs/SecurityConfiguration.java
@@ -11,6 +11,8 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.List;
+
 @Configuration
 public class SecurityConfiguration {
     private final AuthenticationProvider authenticationProvider;
@@ -44,11 +46,11 @@ public class SecurityConfiguration {
     @Bean
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.addAllowedOriginPattern("*");
-        configuration.addAllowedMethod("*");
-        configuration.addAllowedHeader("*");
+        configuration.setAllowedOrigins(List.of("http://localhost:5173"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type"));
         configuration.setAllowCredentials(true);
-        configuration.setMaxAge(3600L); // 1 hour
+        configuration.setMaxAge(3600L);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);


### PR DESCRIPTION
Updated CORS configuration to allow only http://localhost:5173 with specific methods and headers. Improved JWT cookie handling in AuthenticationController by setting SameSite=None, domain, and maxAge for the authentication cookie.