### PR TITLE
Add isConnected field to stakeholder models

### DIFF
--- a/src/main/java/com/startupsphere/capstone/dtos/StakeholderInfoDTO.java
+++ b/src/main/java/com/startupsphere/capstone/dtos/StakeholderInfoDTO.java
@@ -10,6 +10,8 @@ public class StakeholderInfoDTO {
     private String status;
     private LocalDateTime dateJoined;
 
+    private boolean isConnected;
+
     private Long id;
 
     public StakeholderInfoDTO(Stakeholder stakeholder, Long id, String role, String status, LocalDateTime dateJoined) {
@@ -18,14 +20,16 @@ public class StakeholderInfoDTO {
         this.status = status;
         this.dateJoined = dateJoined;
         this.id = id;
+
     }
 
-    public StakeholderInfoDTO(Long id, Stakeholder stakeholder, String role, String status, LocalDateTime dateJoined) {
+    public StakeholderInfoDTO(Long id, Stakeholder stakeholder, String role, String status, LocalDateTime dateJoined,boolean isConnected) {
         this.id = id;
         this.stakeholder = stakeholder;
         this.role = role;
         this.status = status;
         this.dateJoined = dateJoined;
+        this.isConnected = isConnected;
     }
 
     public Stakeholder getStakeholder() {
@@ -34,6 +38,14 @@ public class StakeholderInfoDTO {
 
     public Long getId() {
         return id;
+    }
+
+    public boolean isConnected() {
+        return isConnected;
+    }
+
+    public void setConnected(boolean isConnected) {
+        this.isConnected = isConnected;
     }
 
     public void setId(Long id) {

--- a/src/main/java/com/startupsphere/capstone/dtos/StartupStakeholderRequest.java
+++ b/src/main/java/com/startupsphere/capstone/dtos/StartupStakeholderRequest.java
@@ -7,11 +7,14 @@ public class StartupStakeholderRequest {
     private String status;
     private Long startupId;
 
-    public StartupStakeholderRequest(Long stakeholderId, String role, String status, Long startupId) {
+    private boolean isConnected;
+
+    public StartupStakeholderRequest(Long stakeholderId, String role, String status, Long startupId, boolean isConnected) {
         this.stakeholderId = stakeholderId;
         this.role = role;
         this.status = status;
         this.startupId = startupId;
+        this.isConnected = isConnected;
     }
 
     public Long getStakeholderId() {
@@ -20,6 +23,14 @@ public class StartupStakeholderRequest {
 
     public void setStakeholderId(Long stakeholderId) {
         this.stakeholderId = stakeholderId;
+    }
+
+    public boolean isConnected() {
+        return isConnected;
+    }
+
+    public void setConnected(boolean connected) {
+        isConnected = connected;
     }
 
     public String getRole() {

--- a/src/main/java/com/startupsphere/capstone/entity/Stakeholder.java
+++ b/src/main/java/com/startupsphere/capstone/entity/Stakeholder.java
@@ -1,11 +1,13 @@
 package com.startupsphere.capstone.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
 @Table(name = "stakeholders")
+@JsonIgnoreProperties({"startupStakeholders"})
 public class Stakeholder {
 
     @Id
@@ -259,6 +261,14 @@ public class Stakeholder {
 
     public void setLocationLng(Double locationLng) {
         this.locationLng = locationLng;
+    }
+
+    public List<StartupStakeholder> getStartupStakeholders() {
+        return startupStakeholders;
+    }
+
+    public void setStartupStakeholders(List<StartupStakeholder> startupStakeholders) {
+        this.startupStakeholders = startupStakeholders;
     }
 
 }

--- a/src/main/java/com/startupsphere/capstone/entity/Startup.java
+++ b/src/main/java/com/startupsphere/capstone/entity/Startup.java
@@ -1,6 +1,7 @@
 package com.startupsphere.capstone.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -8,6 +9,7 @@ import java.util.List;
 
 @Entity
 @Table(name = "startups")
+@JsonIgnoreProperties({"startupStakeholders", "likes", "bookmarks", "views", "notifications"})
 public class Startup {
 
     @Id
@@ -706,5 +708,13 @@ public class Startup {
 
     public void setRegistrationCertificate(byte[] registrationCertificate) {
         this.registrationCertificate = registrationCertificate;
+    }
+
+    public List<StartupStakeholder> getStartupStakeholders() {
+        return startupStakeholders;
+    }
+
+    public void setStartupStakeholders(List<StartupStakeholder> startupStakeholders) {
+        this.startupStakeholders = startupStakeholders;
     }
 }

--- a/src/main/java/com/startupsphere/capstone/entity/StartupStakeholder.java
+++ b/src/main/java/com/startupsphere/capstone/entity/StartupStakeholder.java
@@ -1,5 +1,6 @@
 package com.startupsphere.capstone.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import org.hibernate.annotations.CreationTimestamp;
 
@@ -7,6 +8,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "startup_stakeholders")
+@JsonIgnoreProperties({"startupStakeholders"})
 public class StartupStakeholder {
 
     @Id
@@ -31,15 +33,18 @@ public class StartupStakeholder {
     @Column(nullable = false)
     private String status;
 
+    private boolean isConnected;
+
     public StartupStakeholder() {
     }
 
-    public StartupStakeholder(Startup startup, Stakeholder stakeholder, String role, LocalDateTime dateJoined, String status) {
+    public StartupStakeholder(Startup startup, Stakeholder stakeholder, String role, LocalDateTime dateJoined, String status, boolean isConnected) {
         this.startup = startup;
         this.stakeholder = stakeholder;
         this.role = role;
         this.dateJoined = dateJoined;
         this.status = status;
+        this.isConnected = isConnected;
     }
 
     // Getters and Setters
@@ -49,6 +54,14 @@ public class StartupStakeholder {
 
     public void setId(Long id) {
         this.id = id;
+    }
+
+    public boolean isConnected() {
+        return isConnected;
+    }
+
+    public void setConnected(boolean connected) {
+        isConnected = connected;
     }
 
     public Startup getStartup() {

--- a/src/main/java/com/startupsphere/capstone/repository/StartupStakeholderRepository.java
+++ b/src/main/java/com/startupsphere/capstone/repository/StartupStakeholderRepository.java
@@ -11,6 +11,6 @@ import java.util.List;
 public interface StartupStakeholderRepository extends JpaRepository<StartupStakeholder, Long> {
     List<StartupStakeholder> findByStartupId(Long startupId);
 
-    @Query("SELECT new com.startupsphere.capstone.dtos.StakeholderInfoDTO(ss.id, ss.stakeholder, ss.role, ss.status, ss.dateJoined) FROM StartupStakeholder ss WHERE ss.startup.id = :startupId")
+    @Query("SELECT new com.startupsphere.capstone.dtos.StakeholderInfoDTO(ss.id, ss.stakeholder, ss.role, ss.status, ss.dateJoined, ss.isConnected) FROM StartupStakeholder ss WHERE ss.startup.id = :startupId")
     List<com.startupsphere.capstone.dtos.StakeholderInfoDTO> findStakeholderInfoByStartupId(@Param("startupId") Long startupId);
 }

--- a/src/main/java/com/startupsphere/capstone/service/StakeholderService.java
+++ b/src/main/java/com/startupsphere/capstone/service/StakeholderService.java
@@ -1,6 +1,7 @@
 package com.startupsphere.capstone.service;
 
 import com.startupsphere.capstone.entity.Stakeholder;
+import com.startupsphere.capstone.entity.StartupStakeholder;
 import com.startupsphere.capstone.repository.StakeholderRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -36,8 +37,20 @@ public class StakeholderService {
         return repository.save(stakeholder);
     }
 
+    @Transactional
     public void deleteById(Long id) {
-        repository.deleteById(id);
+        repository.findById(id).ifPresent(stakeholder -> {
+            // Delete associated StartupStakeholder entries
+            List<StartupStakeholder> associatedStartupStakeholders = stakeholder.getStartupStakeholders();
+            if (associatedStartupStakeholders != null && !associatedStartupStakeholders.isEmpty()) {
+                for (StartupStakeholder startupStakeholder : associatedStartupStakeholders) {
+                    startupStakeholder.getStartup().getStartupStakeholders().remove(startupStakeholder);
+                }
+            }
+
+            // Delete the Stakeholder
+            repository.deleteById(id);
+        });
     }
 
     @Transactional

--- a/src/main/java/com/startupsphere/capstone/service/StartupStakeholderService.java
+++ b/src/main/java/com/startupsphere/capstone/service/StartupStakeholderService.java
@@ -49,6 +49,7 @@ public class StartupStakeholderService {
         startupStakeholder.setStakeholder(stakeholder);
         startupStakeholder.setRole(request.getRole());
         startupStakeholder.setStatus(request.getStatus());
+        startupStakeholder.setConnected(true); // Default to connected when created
         return repository.save(startupStakeholder);
     }
 
@@ -73,7 +74,7 @@ public class StartupStakeholderService {
                     // Update other fields
                     existing.setRole(request.getRole());
                     existing.setStatus(request.getStatus());
-
+                    existing.setConnected(request.isConnected());
                     return ResponseEntity.ok(repository.save(existing));
                 })
                 .orElse(ResponseEntity.notFound().build());


### PR DESCRIPTION
Introduces an isConnected boolean field to StakeholderInfoDTO, StartupStakeholderRequest, and StartupStakeholder entities. Updates constructors, getters, setters, and repository queries to support this field. StakeholderService and StartupStakeholderService are updated to handle isConnected logic during creation, update, and deletion of stakeholders.