### PR TITLE
Add filtered startup retrieval and email duplication check

### DIFF
--- a/src/main/java/com/startupsphere/capstone/controller/StakeholderController.java
+++ b/src/main/java/com/startupsphere/capstone/controller/StakeholderController.java
@@ -3,10 +3,13 @@ package com.startupsphere.capstone.controller;
 import com.startupsphere.capstone.entity.Stakeholder;
 import com.startupsphere.capstone.service.StakeholderService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/stakeholders")
@@ -32,8 +35,23 @@ public class StakeholderController {
     }
 
     @PostMapping
-    public Stakeholder create(@RequestBody Stakeholder stakeholder) {
-        return service.save(stakeholder);
+    public ResponseEntity<?> create(@RequestBody Stakeholder stakeholder) {
+        try {
+            Optional<Stakeholder> existingStakeholder = service.findByEmail(stakeholder.getEmail());
+            if (existingStakeholder.isPresent()) {
+                return ResponseEntity
+                        .status(HttpStatus.CONFLICT)
+                        .body(Map.of("error", "Email already exists",
+                                "message", "A stakeholder with this email is already registered"));
+            }
+            Stakeholder savedStakeholder = service.save(stakeholder);
+            return ResponseEntity.status(HttpStatus.CREATED).body(savedStakeholder);
+        } catch (Exception e) {
+            return ResponseEntity
+                    .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "Failed to create stakeholder",
+                            "message", e.getMessage()));
+        }
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/startupsphere/capstone/controller/StartupController.java
+++ b/src/main/java/com/startupsphere/capstone/controller/StartupController.java
@@ -438,6 +438,31 @@ public class StartupController {
                 .body(file);
     }
 
+    @GetMapping("/review")
+    public ResponseEntity<List<Startup>> getStartupsWithFilters(
+            @RequestParam(required = false) String industry,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) String region,
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false) String startDate,
+            @RequestParam(required = false) String endDate) {
+
+        try {
+            List<Startup> startups = startupService.getStartupsWithFilters(
+                    industry,
+                    status,
+                    region,
+                    search,
+                    startDate,
+                    endDate
+            );
+            return ResponseEntity.ok(startups);
+        } catch (Exception e) {
+            logger.error("Error fetching filtered startups: {}", e.getMessage(), e);
+            return ResponseEntity.status(500).build();
+        }
+    }
+
     public static class VerificationRequest {
         private Long startupId;
         private String email;

--- a/src/main/java/com/startupsphere/capstone/exceptions/DuplicateEmailException.java
+++ b/src/main/java/com/startupsphere/capstone/exceptions/DuplicateEmailException.java
@@ -1,0 +1,7 @@
+package com.startupsphere.capstone.exceptions;
+
+public class DuplicateEmailException extends RuntimeException {
+    public DuplicateEmailException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/startupsphere/capstone/repository/StartupRepository.java
+++ b/src/main/java/com/startupsphere/capstone/repository/StartupRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import com.startupsphere.capstone.entity.Startup;
+import org.springframework.data.repository.query.Param;
 
 public interface StartupRepository extends JpaRepository<Startup, Long> {
     List<Startup> findByCompanyNameContainingIgnoreCase(String query);
@@ -25,6 +26,22 @@ public interface StartupRepository extends JpaRepository<Startup, Long> {
 
     @Query("SELECT s FROM Startup s WHERE s.status = 'Approved'")
     List<Startup> findAllApprovedStartups();
+
+    @Query("SELECT s FROM Startup s WHERE " +
+            "(:industry IS NULL OR s.industry = :industry) AND " +
+            "(:status IS NULL OR s.status = :status) AND " +
+            "(:region IS NULL OR s.region = :region) AND " +
+            "(:search IS NULL OR LOWER(s.companyName) LIKE LOWER(CONCAT('%', :search, '%')) OR LOWER(s.companyDescription) LIKE LOWER(CONCAT('%', :search, '%'))) AND " +
+            "(:startDate IS NULL OR s.createdAt >= :startDate) AND " +
+            "(:endDate IS NULL OR s.createdAt <= :endDate)")
+    List<Startup> findStartupsWithFilters(
+            @Param("industry") String industry,
+            @Param("status") String status,
+            @Param("region") String region,
+            @Param("search") String search,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate
+    );
 
     @Query("SELECT s FROM Startup s WHERE s.lastUpdated < :threshold AND s.emailVerified = true")
     List<Startup> findStartupsNotUpdatedSince(LocalDateTime threshold);

--- a/src/main/java/com/startupsphere/capstone/service/StartupService.java
+++ b/src/main/java/com/startupsphere/capstone/service/StartupService.java
@@ -25,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.startupsphere.capstone.repository.ViewsRepository;
 
 import java.io.IOException;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -412,5 +413,28 @@ public class StartupService {
             logger.error("IOException while sending reminder email to {}: {}", toEmail, e.getMessage(), e);
             throw new RuntimeException("Failed to send reminder email: " + e.getMessage(), e);
         }
+    }
+
+    public List<Startup> getStartupsWithFilters(
+            String industry,
+            String status,
+            String region,
+            String search,
+            String startDate,
+            String endDate) {
+
+        LocalDateTime parsedStartDate = startDate != null ?
+                LocalDate.parse(startDate).atStartOfDay() : null;
+        LocalDateTime parsedEndDate = endDate != null ?
+                LocalDate.parse(endDate).atTime(23, 59, 59) : null;
+
+        return startupRepository.findStartupsWithFilters(
+                industry,
+                status,
+                region,
+                search,
+                parsedStartDate,
+                parsedEndDate
+        );
     }
 }


### PR DESCRIPTION
Introduces a new endpoint to retrieve startups with multiple filters in StartupController and implements the corresponding repository query and service logic. Adds duplicate email validation to StakeholderController's creation endpoint and a custom DuplicateEmailException. These changes improve data integrity and enable more flexible startup review workflows.