### PR TITLE
Add endpoint to fetch distinct startup industries

### DIFF
--- a/src/main/java/com/startupsphere/capstone/controller/StartupController.java
+++ b/src/main/java/com/startupsphere/capstone/controller/StartupController.java
@@ -467,6 +467,17 @@ public class StartupController {
         }
     }
 
+    @GetMapping("/industries")
+    public ResponseEntity<List<String>> getDistinctIndustries() {
+        try {
+            List<String> industries = startupService.getDistinctIndustries();
+            return ResponseEntity.ok(industries);
+        } catch (Exception e) {
+            logger.error("Error fetching distinct industries: {}", e.getMessage(), e);
+            return ResponseEntity.status(500).build();
+        }
+    }
+
     public static class VerificationRequest {
         private Long startupId;
         private String email;

--- a/src/main/java/com/startupsphere/capstone/repository/StartupRepository.java
+++ b/src/main/java/com/startupsphere/capstone/repository/StartupRepository.java
@@ -45,4 +45,7 @@ public interface StartupRepository extends JpaRepository<Startup, Long> {
 
     @Query("SELECT s FROM Startup s WHERE s.lastUpdated < :threshold AND s.emailVerified = true")
     List<Startup> findStartupsNotUpdatedSince(LocalDateTime threshold);
+
+    @Query("SELECT DISTINCT s.industry FROM Startup s WHERE s.industry IS NOT NULL")
+    List<String> findDistinctIndustries();
 }

--- a/src/main/java/com/startupsphere/capstone/service/StartupService.java
+++ b/src/main/java/com/startupsphere/capstone/service/StartupService.java
@@ -437,4 +437,8 @@ public class StartupService {
                 parsedEndDate
         );
     }
+
+    public List<String> getDistinctIndustries() {
+        return startupRepository.findDistinctIndustries();
+    }
 }


### PR DESCRIPTION
Introduces a new GET /industries endpoint in StartupController to retrieve a list of distinct industries from startups. Implements supporting repository query and service method to provide the data.